### PR TITLE
elimino el color blanco del titulo de la seccion

### DIFF
--- a/src/components/NewMovies.jsx
+++ b/src/components/NewMovies.jsx
@@ -32,7 +32,7 @@ function NewMovies() {
 
   return (
     <Box>
-        <Typography variant="h4" align="center" p={2} sx={{color:"white"}}>
+        <Typography variant="h4" align="center" p={2}>
           New movies
         </Typography>
       <Box sx={{ display: "flex", flexWrap: "wrap" }} p={3}>


### PR DESCRIPTION
Había agregado el color blanco para el titulo de la sección porque tenia el fondo negro (que finalmente lo saqué) y olvidé cambiarlo.